### PR TITLE
Add create-react-class dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": ">=0.14.0"
   },
   "dependencies": {
+    "create-react-class": "^15.6.3",
     "fbemitter": "^2.0.2",
     "fbjs": "~0",
     "prop-types": "^15.5.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1377,6 +1377,15 @@ coveralls@~2.11.2:
     minimist "1.2.0"
     request "2.79.0"
 
+create-react-class@^15.6.3:
+  version "15.6.3"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
+  integrity sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -3266,7 +3275,7 @@ object-assign@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-2.1.1.tgz#43c36e5d569ff8e4816c4efa8be02d26967c18aa"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 


### PR DESCRIPTION
It appears this forked library added `create-react-class` functionality but without specifying it as a dependency. A `react-redux` update in PocketDerm appears to be failing because `react-redux` no longer specifies `create-react-class` as a dependency, and so in the update `PocketDerm` no longer has it, causing use of this library to fail.

This PR *should* fix that. Going to test it now. 